### PR TITLE
Kconfig: add unmet dependencies

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -88,6 +88,10 @@ config DOCKER
 
 	select CPUSETS
 
+	select BLOCK
+
+	select BLK_CGROUP
+
 	select BLK_DEV_THROTTLING
 
 	select KEYS


### PR DESCRIPTION
warning: (DOCKER) selects BLK_DEV_THROTTLING which has unmet direct dependencies (BLOCK && BLK_CGROUP)